### PR TITLE
Feature/timeout based maxtime

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -303,6 +303,7 @@ async function dowloadAsset(
 async function downloadurl(url, target, reference, stopWatch) {
   console.log('Downloading to ' + target)
   try {
+    const timeout = reference?.remainingTime && reference?.remainingTime * 1000
     await pipeline(
       got.stream(url, {
         timeout: {
@@ -310,8 +311,8 @@ async function downloadurl(url, target, reference, stopWatch) {
           connect: 1000,
           secureConnect: 1000,
           socket: 60000,
-          send: reference?.remainingTime || 10000,
-          response: reference?.remainingTime || 30000
+          send: timeout || 10000,
+          response: timeout || 30000
         }
       }),
       fs.createWriteStream(target)

--- a/src/index.js
+++ b/src/index.js
@@ -309,6 +309,7 @@ async function downloadurl(url, target, reference, stopWatch) {
   try {
     stopWatch = process.hrtime(stopWatch)
     const timeout = (reference.maxtime - stopWatch[0]) * 1000
+    console.log('Download response timeout: ' + timeout + '.')
     stopWatch = process.hrtime(stopWatch)
     await pipeline(
       got.stream(url, {


### PR DESCRIPTION
Fixes #37  .

Changes proposed in this PR:

- Request timeout based on provider fee . compute env . max time
- Required this because while provider response chunked file or json, client only able to read response header as the whole response completed, thus, even with timeout socket handshake remain intact, timeout send or response will still timed out. 
- 