### PR TITLE
Increase downloadurl timeout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -281,7 +281,7 @@ async function downloadurl(url, target) {
     await pipeline(
       got.stream(url, {
         timeout: {
-          request: 10000
+          request: 120000
         }
       }),
       fs.createWriteStream(target)


### PR DESCRIPTION
I have experienced many timeouts while downloading big files from our local provider. We propose increasing it significantly to reduce the risk of losing a compute request due to this error.

Changes proposed in this PR:

- In `downloadurl(url, target)`, increase `got.stream()` timeout from `10000` to `120000`